### PR TITLE
[GITHUB-4] Add AWS credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,43 @@ Build GO CD agent for AWS ASG:
             - s3_path: s3://config.my.org.domain/gocd_agent/prd/ssh/id_rsa.pub
               local_path: "/home/go/.ssh"
               mode: 0600
+```
 
+Build Go CD agent with AWS profile configured
+
+```YAML
+- name: Install GO CD Agent
+  hosts: sandbox
+
+  pre_tasks:
+    - name: Update apt
+      become: yes
+      apt:
+        cache_valid_time: 1800
+        update_cache: yes
+      tags:
+        - build
+
+  roles:
+    - name: sansible.gocd_agent
+      gocd_agent:
+        gocd_server_lookup_filter: Name=tag:Environment,Values=prd Name=tag:Role,Values=gocd_server
+        aws:
+          profiles:
+            - name: production_access
+              config:
+                role_arn: "arn:aws:iam::123456654321:role/ReleaseBot"
+                source_profile: default
+                s3:
+                  max_queue_size: 1000
+```
+
+This will create the following ~/.aws/credentials
+
+```
+[production_access]
+s3 =
+  max_queue_size = 1000
+role_arn = arn:aws:iam::123456654321:role/ReleaseBot
+source_profile = default
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,13 @@ gocd_agent:
     #    mode: 0600
     s3_secret_files: [ ]
 
+    # List of profiles to configure in ~/.aws/credentials
+    # - name: production
+    #   config:
+    #     role_arn:
+    #     source_profile: default
+    profiles: []
+
   git:
     email: gocd@example.com
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -28,21 +28,37 @@
   when: gocd_agent.aws.gocd_server_lookup_filter
 
 - name: Copy secrets from S3
-  sudo: yes
-  sudo_user: "{{ gocd_agent.user }}"
+  become: yes
+  become_user: "{{ gocd_agent.user }}"
   shell: "aws s3 cp --region {{ gocd_agent.aws.region }} {{ item.s3_path }} {{ item.local_path }}"
   args:
     creates: "{{ item.local_path }}"
   with_items: gocd_agent.aws.s3_secret_files
 
 - name: Secure secrets from S3
-  sudo: yes
+  become: yes
   file:
     group: "{{ gocd_agent.user }}"
     mode: "{{ item.mode | default(0600) }}"
     owner: "{{ gocd_agent.user }}"
     path: "{{ item.local_path }}"
   with_items: gocd_agent.aws.s3_secret_files
+
+- name: Ensure .aws folder
+  become: yes
+  file:
+    state: directory
+    path: "/home/{{ gocd_agent.user }}/.aws"
+    owner: "{{ gocd_agent.user }}"
+    group: "{{ gocd_agent.user }}"
+  when: gocd_agent.aws.profiles
+
+- name: Configure AWS credentials
+  become: yes
+  template:
+    dest: "/home/{{ gocd_agent.user }}/.aws/credentials"
+    src: aws/credentials.j2
+  when: gocd_agent.aws.profiles
 
 - name: Configure SSH
   become: yes

--- a/templates/aws/credentials.j2
+++ b/templates/aws/credentials.j2
@@ -1,0 +1,13 @@
+{% for profile in gocd_agent.aws.profiles %}
+[{{ profile.name }}]
+{% for key, value in profile.config.iteritems() %}
+{% if value is mapping %}
+{{ key }} =
+{% for sub_key, sub_value in value.iteritems() %}
+  {{ sub_key }} = {{ sub_value }}
+{% endfor %}
+{% else%}
+{{ key }} = {{ value }}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/tests/vagrant/test.yml
+++ b/tests/vagrant/test.yml
@@ -16,3 +16,11 @@
     - role: sansible.gocd_agent
       gocd_agent:
         no_of_agents: 2
+        aws:
+          profiles:
+            - name: testProfile
+              config:
+                role_arn: "arn::::"
+                source_profile: default
+                s3:
+                  max_queue_size: 1000


### PR DESCRIPTION
You can use it if you want to controll more then one AWS account from
you gocd_agent with multiple IAM roles.