### PR TITLE
[2195] Changed sudo to become

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: start go-agent
-  sudo: yes
+  become: yes
   service:
     name: go-agent
     state: started
 
 - name: stop go-agent
-  sudo: yes
+  become: yes
   service:
     name: go-agent
     state: stopped
 
 - name: restart go-agent
-  sudo: yes
+  become: yes
   service:
     name: go-agent-{{ item }}
     state: restarted


### PR DESCRIPTION
As part of making this repo work with Ansible 2.1.1, the `sudo` directive has been changed to `become`.