### PR TITLE
[GITHUB-23] Updates key URL to work with proxies

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,7 @@
 - name: Add GoCD Apt key
   become: yes
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: hkp://keyserver.ubuntu.com:80
     id: "{{ gocd_agent.repo.key_id }}"
     state: present
 


### PR DESCRIPTION
Adds hkp schema which seems to make gpg install work behind a
corporate proxy.