### PR TITLE
GITHUB-27 Replaces GO_SERVER and GO_SERVER_PORT with GO_SERVEL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To simply install GO CD agent:
 
   roles:
     - name: sansible.gocd_agent
-      sansible_gocd_agent_server: IP.OR.URL.OF.THE.GOCD.SERVER
+      sansible_gocd_agent_server_url: https://127.0.0.1:8154/go (Change the IP address 127.0.0.1 to the hostname or IP address of your GoCD server.)
 ```
 
 Build GO CD agent for AWS ASG:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,10 +52,9 @@ sansible_gocd_agent_packages:
   - python-pip
   - python-setuptools
 
-sansible_gocd_agent_port: 8153
 sansible_gocd_agent_repo_key_id: 8816C449
 sansible_gocd_agent_repo_source: deb https://download.gocd.org /
-sansible_gocd_agent_server: localhost
+sansible_gocd_agent_server_url: https://127.0.0.1:8154/go
 sansible_gocd_agent_start_opts: ~
 sansible_gocd_agent_user: go
 sansible_gocd_agent_user_dir: /home/go

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -83,7 +83,7 @@
 
 - name: Set IP of GoCD server
   set_fact:
-    sansible_gocd_agent_server: "{{ gocd_server_lookup.instances[0].private_ip_address }}"
+    sansible_gocd_agent_server_url: "{{ gocd_server_lookup.instances[0].private_ip_address }}"
   when:
     - gocd_server_lookup is defined
     - gocd_server_lookup.instances | default([]) != []

--- a/templates/defaults.j2
+++ b/templates/defaults.j2
@@ -1,6 +1,5 @@
 # {{ ansible_managed }}
-export GO_SERVER={{ sansible_gocd_agent_server }}
-export GO_SERVER_PORT={{ sansible_gocd_agent_port }}
+export GO_SERVER_URL={{ sansible_gocd_agent_server_url }}
 {% if sansible_gocd_agent_start_opts is not none %}
 export GO_AGENT_SYSTEM_PROPERTIES="{{ sansible_gocd_agent_start_opts }}"
 {% endif %}


### PR DESCRIPTION
- Updated the README with the example of the GO_SERVER_URL
- changed the variable **_sansible_gocd_agent_server_** to **_sansible_gocd_agent_server_url_** to make it more consistent with the change in GOCD server configuration.
- removed variable **_sansible_gocd_agent_port_** from defaults since it is no longer being used.