### PR TITLE
[GITHUB-27] Adds GO_SERVER_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ or add this to your `roles.yml`
 
 ```YAML
 - name: sansible.gocd_agent
-  version: v3.0
+  version: v3.1
 ```
 
 and run `ansible-galaxy install -p ./roles -r roles.yml`
@@ -64,7 +64,7 @@ To simply install GO CD agent:
 
   roles:
     - name: sansible.gocd_agent
-      sansible_gocd_agent_server: IP.OR.URL.OF.THE.GOCD.SERVER
+      sansible_gocd_agent_server_url: https://127.0.0.1:8154/go
 ```
 
 Build GO CD agent for AWS ASG:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,8 @@ sansible_gocd_agent_port: 8153
 sansible_gocd_agent_repo_key_id: 8816C449
 sansible_gocd_agent_repo_source: deb https://download.gocd.org /
 sansible_gocd_agent_server: localhost
+sansible_gocd_agent_server_url: https://127.0.0.1:8154/go
+sansible_gocd_agent_start_on_boot: yes
 sansible_gocd_agent_start_opts: ~
 sansible_gocd_agent_user: go
 sansible_gocd_agent_user_dir: /home/go

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@
 galaxy_info:
   description: "Install the Go Continuous Delivery agent."
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.5
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -188,3 +188,4 @@
     name: "go-agent-{{ item }}"
     state: started
   with_sequence: count="{{ sansible_gocd_agent_no_of_agents }}"
+  when: sansible_gocd_agent_start_on_boot == true

--- a/templates/defaults.j2
+++ b/templates/defaults.j2
@@ -1,9 +1,25 @@
+#jinja2: lstrip_blocks: True
+##
 # {{ ansible_managed }}
+#
+
+{% if sansible_gocd_agent_server_url | length > 0 %}
+
+export GO_SERVER_URL={{ sansible_gocd_agent_server_url }}
+
+{% else %}
+
 export GO_SERVER={{ sansible_gocd_agent_server }}
-export GO_SERVER_PORT={{ sansible_gocd_agent_port }}
-{% if sansible_gocd_agent_start_opts is not none %}
-export GO_AGENT_SYSTEM_PROPERTIES="{{ sansible_gocd_agent_start_opts }}"
+export GO_SERVER_URL={{ sansible_gocd_agent_port }}
+
 {% endif %}
+
+{% if sansible_gocd_agent_start_opts is not none %}
+
+export GO_AGENT_SYSTEM_PROPERTIES="{{ sansible_gocd_agent_start_opts }}"
+
+{% endif %}
+
 export AGENT_WORK_DIR={{ sansible_gocd_agent_user_dir }}/work/${SERVICE_NAME}
 export AGENT_MEM={{ sansible_gocd_agent_mem }}
 export AGENT_MAX_MEM={{ sansible_gocd_agent_max_mem }}


### PR DESCRIPTION
This is the new method for addressing GoCD Server from an agent,
also adds an option to not autostart the agents on boot.