### PR TITLE
[GITHUB-27] Fixes dynamic server lookup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ sansible_gocd_agent_packages:
   - python-setuptools
 
 sansible_gocd_agent_port: 8153
+sansible_gocd_agent_port_https: 8154
 sansible_gocd_agent_repo_key_id: 8816C449
 sansible_gocd_agent_repo_source: deb https://download.gocd.org /
 sansible_gocd_agent_server: localhost

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -86,12 +86,13 @@
 - name: Query AWS for GoCD Server
   ec2_remote_facts:
     filters: "{{ sansible_gocd_agent_aws_gocd_server_lookup_filters }}"
+    region: "{{ sansible_gocd_agent_aws_region }}"
   register: gocd_server_lookup
   when: sansible_gocd_agent_aws_gocd_server_lookup_filters != {}
 
 - name: Set IP of GoCD server
   set_fact:
-    sansible_gocd_agent_server: "{{ gocd_server_lookup.instances[0].private_ip_address }}"
+    sansible_gocd_agent_server_url: "https://{{ gocd_server_lookup.instances[0].private_ip_address }}:{{ sansible_gocd_agent_port_https }}/go"
   when:
     - gocd_server_lookup is defined
     - gocd_server_lookup.instances | default([]) != []

--- a/templates/defaults.j2
+++ b/templates/defaults.j2
@@ -25,7 +25,6 @@ export AGENT_MEM={{ sansible_gocd_agent_mem }}
 export AGENT_MAX_MEM={{ sansible_gocd_agent_max_mem }}
 
 DAEMON=Y
-VNC=N
 
 export GOPATH=/home/{{ sansible_gocd_agent_user }}/go
 export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
Ensures that the new GO_SERVER_URL env var works with the
dynamic AWS lookup.

Also removed VNC var which is no longer used by GoCD.