### PR TITLE
[GITHUB-63] Fixes handlers after the 19.6 upgrade

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,22 +1,22 @@
 ---
 
-- name: start go-agent
+- name: start go agents
   become: yes
   service:
-    name: go-agent-{{ item }}
+    name: go-{{ item }}
     state: started
-  with_sequence: count={{ sansible_gocd_agent_no_of_agents }}
+  loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"
 
-- name: stop go-agent
+- name: stop go agents
   become: yes
   service:
-    name: go-agent-{{ item }}
+    name: go-{{ item }}
     state: stopped
-  with_sequence: count={{ sansible_gocd_agent_no_of_agents }}
+  loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"
 
-- name: restart go-agent
+- name: restart go agents
   become: yes
   service:
-    name: go-agent-{{ item }}
+    name: go-{{ item }}
     state: restarted
-  with_sequence: count={{ sansible_gocd_agent_no_of_agents }}
+  loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -123,6 +123,7 @@
     owner: "{{ sansible_gocd_agent_user }}"
     src: wrapper-properties.conf.j2
   loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"
+  notify: restart go agents
 
 - name: Symlink the wrapper binaries for additional agents
   become: yes
@@ -152,7 +153,7 @@
     src: autoregister.properties.j2
   loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"
   when: sansible_gocd_agent_auto_register_key is not none
-  notify: restart go-agent
+  notify: restart go agents
 
 - name: Run install command for additional agents
   become: yes


### PR DESCRIPTION
Fixes the name of the service used in the handlers, it's now
go- as opposed to go-agent-.