### PR TITLE
[GITHUB-65] Adds retries to Agent installation

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -162,6 +162,9 @@
     creates: "/etc/systemd/system/go-{{ item }}.service"
   register: sansible_gocd_agent_install_cmd_result
   loop: "{{ range(1, sansible_gocd_agent_no_of_agents + 1) | list }}"
+  until: sansible_gocd_agent_install_cmd_result is succeeded
+  retries: 3
+  delay: 5
 
 - name: Ensure startup scripts are registered for SystemD
   become: yes


### PR DESCRIPTION
The install script supplied by GoCD seems to fail sometimes due
to it not detecting SystemD properly, this change adds some retries
to try to workaround this issue as it seems to fail even when
SystemD is most definitely running.