### PR TITLE
[GITHUB-67] Ensures AUTH SOCK var for agents

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,8 @@ platforms:
 
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_LOCAL_TEMP: /tmp
 
 lint: |
   set -e

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
+ansible==2.9.13
 ansible-lint==4.2.0
 docker==4.2.2
 flake8==3.8.3
 molecule==3.0.6
+pytest==3.9.3
 testinfra==5.2.2
+yamllint==1.24.2

--- a/templates/wrapper-properties.conf.j2
+++ b/templates/wrapper-properties.conf.j2
@@ -2,6 +2,8 @@
 # {{ ansible_managed }}
 
 set.AGENT_STARTUP_ARGS=-Xms{{ sansible_gocd_agent_mem }} -Xmx{{ sansible_gocd_agent_max_mem }}
+set.SSH_AUTH_SOCK=/home/{{ sansible_gocd_agent_user }}/.ssh/agent-socket
+
 wrapper.app.parameter.100=-serverUrl
 wrapper.app.parameter.101={{ sansible_gocd_agent_server_url }}
 


### PR DESCRIPTION
Ensures that the AUTH SOCK env var is available to the agent
process.

Also fixes some scaffolding bits.